### PR TITLE
Additional security fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # simple-trpc
 Dumb Simple Typescript RPC!
 
-[![Foo](https://github.com/vote-by-mail/website/workflows/Node.js%20CI/badge.svg)](https://github.com/tianhuil/simple-trpc/actions?query=workflow%3A%22Node.js+CI%22)
+[![Foo](https://github.com/tianhuil/simple-trpc/workflows/Node.js%20CI/badge.svg)](https://github.com/tianhuil/simple-trpc/actions?query=workflow%3A%22Node.js+CI%22)
 [![npm (scoped)](https://img.shields.io/npm/v/@tianhuil/simple-trpc.svg)](https://www.npmjs.com/package/@tianhuil/simple-trpc)
 [![NPM](https://img.shields.io/npm/l/@tianhuil/simple-trpc.svg)](https://www.npmjs.com/package/@tianhuil/simple-trpc)
 [![GitHub package.json dependency version](https://img.shields.io/github/package-json/dependency-version/tianhuil/simple-trpc/dev/@babel/preset-typescript.svg)](https://github.com/tianhuil/simple-trpc/blob/master/package.json)

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -1492,9 +1492,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
-      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
       "dev": true
     },
     "node-notifier": {

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -1235,9 +1235,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "lodash._arraycopy": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tianhuil/simple-trpc",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Dumb Simple Typescript RPC. Zero Codegen (Uses Pure Typescript. Zero dependencies (small footprint). Support for Express and Koa servers.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
We can't fix the other two because `ts-node-dev` uses an outdated version of `node-notifier`, however the production version of `simple-trpc` is relatively fine since apparently the two issues are related to dev environments. `node-notifier` is only used when watching dev builds, and `minimist` used by `babel`/`ts-node-dev` when compiling the app--the vulnerability is only critical if users have access to the arguments passed to the package.

PS: This also fixes the badge